### PR TITLE
row 52 "__version__ == "1.0.1" error, should be __version__ = "1.0.1"

### DIFF
--- a/threadpool.py
+++ b/threadpool.py
@@ -49,7 +49,7 @@ import sys
 import lazy
 import Queue
 
-__version__ == "1.0.1"
+__version__ = "1.0.1"
 
 class Worker(threading.Thread):
     """


### PR DESCRIPTION
please check row 52 in threadpool.py in turbidsoul/xoltar-toolkit
